### PR TITLE
Fix period cluttering with content & remove emphatic style

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -21,7 +21,7 @@
   }
 }
 
-.time-loc {
+.period-loc {
   float: right;
   margin-left: 1em;
 }

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -20,3 +20,8 @@
     }
   }
 }
+
+.time-loc {
+  float: right;
+  margin-left: 1em;
+}

--- a/index.md
+++ b/index.md
@@ -14,25 +14,25 @@ Especially the following domains:
 
 # Education
 
-National Taipei University of Technology
 <span class="time-loc">Taipei, Taiwan</span>
+National Taipei University of Technology
 <br>
-Bachelor of Science in Electronic Engineer
 <span class="time-loc">Sep. 2019 ~ Jun. 2023</span>
+Bachelor of Science in Electronic Engineer
 
 # Experience
 
-Course of Object Oriented Programmin @ NTUT
 <span class="time-loc">Taipei, Taiwan</span>
+Course of Object Oriented Programmin @ NTUT
 <br>
-Teaching Assistant
 <span class="time-loc">Feb. 2021 ~ Jun. 2021</span>
+Teaching Assistant
 
-Advanced Semiconductor Engineering, Inc.
 <span class="time-loc">Kaohsiung, Taiwan</span>
+Advanced Semiconductor Engineering, Inc.
 <br>
-Summer Intern
 <span class="time-loc">Jul. 2022 ~ Aug. 2022</span>
+Summer Intern
 
 # Interest
 

--- a/index.md
+++ b/index.md
@@ -14,24 +14,24 @@ Especially the following domains:
 
 # Education
 
-<span class="time-loc">Taipei, Taiwan</span>
+<span class="period-loc">Taipei, Taiwan</span>
 National Taipei University of Technology
 <br>
-<span class="time-loc">Sep. 2019 ~ Jun. 2023</span>
+<span class="period-loc">Sep. 2019 ~ Jun. 2023</span>
 Bachelor of Science in Electronic Engineer
 
 # Experience
 
-<span class="time-loc">Taipei, Taiwan</span>
+<span class="period-loc">Taipei, Taiwan</span>
 Course of Object Oriented Programmin @ NTUT
 <br>
-<span class="time-loc">Feb. 2021 ~ Jun. 2021</span>
+<span class="period-loc">Feb. 2021 ~ Jun. 2021</span>
 Teaching Assistant
 
-<span class="time-loc">Kaohsiung, Taiwan</span>
+<span class="period-loc">Kaohsiung, Taiwan</span>
 Advanced Semiconductor Engineering, Inc.
 <br>
-<span class="time-loc">Jul. 2022 ~ Aug. 2022</span>
+<span class="period-loc">Jul. 2022 ~ Aug. 2022</span>
 Summer Intern
 
 # Interest

--- a/index.md
+++ b/index.md
@@ -14,35 +14,35 @@ Especially the following domains:
 
 # Education
 
-<span style="float:right;">
+<span class="time-loc">
   <em>Taipei, Taiwan</em>
 </span>
 ***National Taipei University of Technology***,
 \
-<span style="float:right;">
+<span class="time-loc">
   <em>Sep. 2019 ~ Jun. 2023</em>
 </span>
 Bachelor of Science in ***Electronic Engineering***
 
 # Experience
 
-<span style="float:right;">
+<span class="time-loc">
   <em>Taipei, Taiwan</em>
 </span>
-\
-<span style="float:right;">
+***Course of Object Oriented Programming*** @ NTUT \
+<span class="time-loc">
   <em>Feb. 2021 ~ Jun. 2021</em>
 </span>
-***Teaching Assistant****, Object Oriented Programming*
+*Teaching Assistant*
 
-<span style="float:right;">
+<span class="time-loc">
   <em>Kaohsiung, Taiwan</em>
 </span>
-\
-<span style="float:right;">
+***Advanced Semiconductor Engineering, Inc.***, \
+<span class="time-loc">
   <em>Jul. 2022 ~ Aug. 2022</em>
 </span>
-***Summer Internship****, Advanced Semiconductor Engineering, Inc.*
+*Summer Intern*
 
 # Interest
 

--- a/index.md
+++ b/index.md
@@ -14,37 +14,25 @@ Especially the following domains:
 
 # Education
 
-<em>National Taipei University of Technology</em>
-<span class="time-loc">
-<em>Taipei, Taiwan</em>
-</span>
+National Taipei University of Technology
+<span class="time-loc">Taipei, Taiwan</span>
 <br>
-<em>Bachelor of Science</em> in <em>Electronic Engineer</em>
-<span class="time-loc">
-  <em>Sep. 2019 ~ Jun. 2023</em>
-</span>
+Bachelor of Science in Electronic Engineer
+<span class="time-loc">Sep. 2019 ~ Jun. 2023</span>
 
 # Experience
 
-<em>Course of Object Oriented Programmin</em> @ NTUT
-<span class="time-loc">
-  <em>Taipei, Taiwan</em>
-</span>
+Course of Object Oriented Programmin @ NTUT
+<span class="time-loc">Taipei, Taiwan</span>
 <br>
-<em>Teaching Assistant</em>
-<span class="time-loc">
-  <em>Feb. 2021 ~ Jun. 2021</em>
-</span>
+Teaching Assistant
+<span class="time-loc">Feb. 2021 ~ Jun. 2021</span>
 
-<em>Advanced Semiconductor Engineering, Inc.</em>
-<span class="time-loc">
-  <em>Kaohsiung, Taiwan</em>
-</span>
+Advanced Semiconductor Engineering, Inc.
+<span class="time-loc">Kaohsiung, Taiwan</span>
 <br>
-<em>Summer Intern</em>
-<span class="time-loc">
-  <em>Jul. 2022 ~ Aug. 2022</em>
-</span>
+Summer Intern
+<span class="time-loc">Jul. 2022 ~ Aug. 2022</span>
 
 # Interest
 

--- a/index.md
+++ b/index.md
@@ -14,37 +14,37 @@ Especially the following domains:
 
 # Education
 
-<span class="time-loc">
-  <em>Taipei, Taiwan</em>
-</span>
 <em>National Taipei University of Technology</em>
+<span class="time-loc">
+<em>Taipei, Taiwan</em>
+</span>
 <br>
+<em>Bachelor of Science</em> in <em>Electronic Engineer</em>
 <span class="time-loc">
   <em>Sep. 2019 ~ Jun. 2023</em>
 </span>
-<em>Bachelor of Science</em> in <em>Electronic Engineer</em>
 
 # Experience
 
+<em>Course of Object Oriented Programmin</em> @ NTUT
 <span class="time-loc">
   <em>Taipei, Taiwan</em>
 </span>
-<em>Course of Object Oriented Programmin</em> @ NTUT
 <br>
+<em>Teaching Assistant</em>
 <span class="time-loc">
   <em>Feb. 2021 ~ Jun. 2021</em>
 </span>
-<em>Teaching Assistant</em>
 
+<em>Advanced Semiconductor Engineering, Inc.</em>
 <span class="time-loc">
   <em>Kaohsiung, Taiwan</em>
 </span>
-<em>Advanced Semiconductor Engineering, Inc.</em>
 <br>
+<em>Summer Intern</em>
 <span class="time-loc">
   <em>Jul. 2022 ~ Aug. 2022</em>
 </span>
-<em>Summer Intern</em>
 
 # Interest
 

--- a/index.md
+++ b/index.md
@@ -17,19 +17,19 @@ Especially the following domains:
 <span class="time-loc">
   <em>Taipei, Taiwan</em>
 </span>
-***National Taipei University of Technology***,
+*National Taipei University of Technology*
 \
 <span class="time-loc">
   <em>Sep. 2019 ~ Jun. 2023</em>
 </span>
-Bachelor of Science in ***Electronic Engineering***
+*Bachelor of Science* in *Electronic Engineer*
 
 # Experience
 
 <span class="time-loc">
   <em>Taipei, Taiwan</em>
 </span>
-***Course of Object Oriented Programming*** @ NTUT \
+*Course of Object Oriented Programmin* @ NTUT \
 <span class="time-loc">
   <em>Feb. 2021 ~ Jun. 2021</em>
 </span>
@@ -38,7 +38,7 @@ Bachelor of Science in ***Electronic Engineering***
 <span class="time-loc">
   <em>Kaohsiung, Taiwan</em>
 </span>
-***Advanced Semiconductor Engineering, Inc.***, \
+*Advanced Semiconductor Engineering, Inc.* \
 <span class="time-loc">
   <em>Jul. 2022 ~ Aug. 2022</em>
 </span>

--- a/index.md
+++ b/index.md
@@ -17,32 +17,34 @@ Especially the following domains:
 <span class="time-loc">
   <em>Taipei, Taiwan</em>
 </span>
-*National Taipei University of Technology*
-\
+<em>National Taipei University of Technology</em>
+<br>
 <span class="time-loc">
   <em>Sep. 2019 ~ Jun. 2023</em>
 </span>
-*Bachelor of Science* in *Electronic Engineer*
+<em>Bachelor of Science</em> in <em>Electronic Engineer</em>
 
 # Experience
 
 <span class="time-loc">
   <em>Taipei, Taiwan</em>
 </span>
-*Course of Object Oriented Programmin* @ NTUT \
+<em>Course of Object Oriented Programmin</em> @ NTUT
+<br>
 <span class="time-loc">
   <em>Feb. 2021 ~ Jun. 2021</em>
 </span>
-*Teaching Assistant*
+<em>Teaching Assistant</em>
 
 <span class="time-loc">
   <em>Kaohsiung, Taiwan</em>
 </span>
-*Advanced Semiconductor Engineering, Inc.* \
+<em>Advanced Semiconductor Engineering, Inc.</em>
+<br>
 <span class="time-loc">
   <em>Jul. 2022 ~ Aug. 2022</em>
 </span>
-*Summer Intern*
+<em>Summer Intern</em>
 
 # Interest
 

--- a/zh/index.md
+++ b/zh/index.md
@@ -14,25 +14,25 @@ ref: about
 
 # 教育
 
-國立臺北科技大學
 <span class="time-loc">臺北，臺灣</span>
+國立臺北科技大學
 <br>
-電子工程學 學士
 <span class="time-loc">2019 年 9 月～2023 年 6 月</span>
+電子工程學 學士
 
 # 經歷
 
-物件導向程式設計 課程 @ NTUT
 <span class="time-loc">臺北，臺灣</span>
+物件導向程式設計 課程 @ NTUT
 <br>
-課程助教
 <span class="time-loc">2021 年 2 月～2021 年 6 月</span>
+課程助教
 
-日月光半導體製造股份有限公司
 <span class="time-loc">高雄，臺灣</span>
+日月光半導體製造股份有限公司
 <br>
-暑期實習生
 <span class="time-loc">2022 年 7 月～2022 年 8 月</span>
+暑期實習生
 
 # 興趣
 

--- a/zh/index.md
+++ b/zh/index.md
@@ -14,39 +14,28 @@ ref: about
 
 # 教育
 
-<span style="float:right;">
-  <em>臺北，臺灣</em>
-</span>
-***國立臺北科技大學***，
-\
-<span style="float:right;">
-  <em>2019 年 9 月～2023 年 6 月</em>
-</span>
-***電子工程學*** 學士
+國立臺北科技大學
+<span class="time-loc">臺北，臺灣</span>
+<br>
+電子工程學 學士
+<span class="time-loc">2019 年 9 月～2023 年 6 月</span>
 
 # 經歷
 
-<span style="float:right;">
-  <em>臺北，臺灣</em>
-</span>
-\
-<span style="float:right;">
-  <em>2021 年 2 月～2021 年 6 月</em>
-</span>
-***課程助教****，物件導向程式設計*
+物件導向程式設計 課程 @ NTUT
+<span class="time-loc">臺北，臺灣</span>
+<br>
+課程助教
+<span class="time-loc">2021 年 2 月～2021 年 6 月</span>
 
-<span style="float:right;">
-  <em>高雄，臺灣</em>
-</span>
-\
-<span style="float:right;">
-  <em>2022 年 7 月～2022 年 8 月</em>
-</span>
-***暑期實習****，日月光半導體製造股份有限公司*
+日月光半導體製造股份有限公司
+<span class="time-loc">高雄，臺灣</span>
+<br>
+暑期實習生
+<span class="time-loc">2022 年 7 月～2022 年 8 月</span>
 
 # 興趣
 
 - 軟體設計 :computer:
 - 咖啡 :coffee:
 - 桌球 :ping_pong:
-

--- a/zh/index.md
+++ b/zh/index.md
@@ -14,24 +14,24 @@ ref: about
 
 # 教育
 
-<span class="time-loc">臺北，臺灣</span>
+<span class="period-loc">臺北，臺灣</span>
 國立臺北科技大學
 <br>
-<span class="time-loc">2019 年 9 月～2023 年 6 月</span>
+<span class="period-loc">2019 年 9 月～2023 年 6 月</span>
 電子工程學 學士
 
 # 經歷
 
-<span class="time-loc">臺北，臺灣</span>
+<span class="period-loc">臺北，臺灣</span>
 物件導向程式設計 課程 @ NTUT
 <br>
-<span class="time-loc">2021 年 2 月～2021 年 6 月</span>
+<span class="period-loc">2021 年 2 月～2021 年 6 月</span>
 課程助教
 
-<span class="time-loc">高雄，臺灣</span>
+<span class="period-loc">高雄，臺灣</span>
 日月光半導體製造股份有限公司
 <br>
-<span class="time-loc">2022 年 7 月～2022 年 8 月</span>
+<span class="period-loc">2022 年 7 月～2022 年 8 月</span>
 暑期實習生
 
 # 興趣


### PR DESCRIPTION
# What's the problem?

On mobile devices, the `<span>` that shows the period on the right side may get too close to the content on the left (e.g., job title).

## Before (width: 400)

<img title="the layout before fix" src="https://user-images.githubusercontent.com/52515370/217707932-0e4dc6b0-2f22-4aa7-abb0-6c3ff88f3e78.png" width="50%">

## After (width: 400)

I add a "1em" left margin to the `<span>`.

<img title="the layout after fix" src="https://user-images.githubusercontent.com/52515370/217710124-0c3a3616-0ff8-4421-af55-ce1f4c031939.png" width="50%">